### PR TITLE
Changes to work with PyStageLinQ 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ Some features about StageLinQ will also be explored.
  </details>
  
  - `pip install -r install/requirements.txt`
- - in your installed library **PyStageLinQ.py** file, change the variable this way : `ANNOUNCE_IP = "224.0.0.251" `
-`
 
 ## Running
  - (optional) if you created a virtual environnement, run `source venv/bin/activate` (some IDEs can do this automatically)

--- a/modules/stagelinq.py
+++ b/modules/stagelinq.py
@@ -14,7 +14,7 @@ class stagelinq():
         self.receiveFilter=""
 
         self.session=PyStageLinQ.PyStageLinQ(self.new_device_found_callback, name="piratengine StagelinQ")
-        self.thread = threading.Thread(target=self.session.start, args=());
+        self.thread = threading.Thread(target=self.session.start_standalone, args=());
         self.thread.start();
 
     def log(self,text,source='STLQ',severity='INFO',sameline=False):


### PR DESCRIPTION
Mainly setting the startpoint to PyStageLinQ.start_standalone().